### PR TITLE
Link torgap opentimestamps

### DIFF
--- a/CLA-signed/CLA.gorazdko.41F0EA1699A74C1E2FA41B538CF96BC3FF9DBBCE.asc
+++ b/CLA-signed/CLA.gorazdko.41F0EA1699A74C1E2FA41B538CF96BC3FF9DBBCE.asc
@@ -1,0 +1,74 @@
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA512
+
+# Contributor License Agreement
+
+Version 1.0
+
+Name: Gorazd Kovacic
+
+E-Mail: gorazdko@gmail.com
+
+Legal Jurisdiction: Wyoming, United States of America
+
+Project: https://github.com/BlockchainCommons/torgap
+
+Date: 14.12.2020
+
+## Purpose
+
+This agreement gives Blockchain Commons, LLC the permission it needs in order to accept my contributions into its open software project and to manage the intellectual property in that project over time.
+
+## License
+
+I hereby license Blockchain Commons, LLC to:
+
+1.  do anything with my contributions that would otherwise infringe my copyright in them
+
+2.  do anything with my contributions that would otherwise infringe patents that I can or become able to license
+
+3.  sublicense these rights to others on any terms they like
+
+## Reliability
+
+I understand that Blockchain Commons will rely on this license.  I may not revoke this license.
+
+## Awareness
+
+I promise that I am familiar with legal rules, like ["work made for hire" rules](http://worksmadeforhire.com), that can give employers and clients ownership of intellectual property in work that I do.  I am also aware that legal agreements I might sign, like confidential information and invention assignment agreements, will usually give ownership of intellectual property in my work to employers, clients, and companies that I found.  If someone else owns intellectual property in my work, I need their permission to license it.
+
+## Copyright Guarantee
+
+I promise not to offer contributions to the project that contain copyrighted work that I do not have legally binding permission to contribute under these terms.  When I offer a contribution with permission, I promise to document in the contribution who owns copyright in what work, and how they gave permission to contribute it.  If I later become aware that one of my contributions may have copyrighted work of others that I did not have permission to contribute, I will notify Blockchain Commons, in confidence, immediately.
+
+## Patent Guarantee
+
+I promise not to offer contributions to the project that I know infringe patents of others that I do not have permission to contribute under these terms.
+
+## Open Source Guarantee
+
+I promise not to offer contributions that contain or depend on the work of others, unless that work is available under a license that [Blue Oak Council rates bronze or better](https://blueoakconcil.org/list), such as the MIT License, two- or three-clause BSD License, the Apache License Version 2.0, or the Blue Oak Model License 1.0.0.  When I offer a contribution containing or depending on others' work, I promise to document in the contribution who licenses that work, along with copies of their license terms.
+
+## Disclaimers
+
+***As far as the law allows, my contributions come as is, without any warranty or condition.  Other than under [Copyright Guarantee](#copyright-guarantee), [Patent Guarantee](#patent-guarantee), or [Open Source Guarantee](#open-source-guarantee), I will not be liable to anyone for any damages related to my contributions or this contributor license agreement, under any kind of legal claim.***
+
+- ---
+
+To sign this Contributor License Agreement, fill in `$name`, `$email`, and `$date` above. Then sign using GPG using the following command `gpg --armor --clearsign --output ./CLA-signed/CLA.YOURGITHUBNAME.YOURGPGFINGERPRINT.asc CLA.md`, then either submit your signed Contributor License Agreement to this repo as a GPG signed Pull Request or email it to [ChristopherA@BlockchainCommons.com](mailto:ChristopherA@BlockchainCommons.com).
+-----BEGIN PGP SIGNATURE-----
+
+iQIzBAEBCgAdFiEEQfDqFpmnTB4vpBtTjPlrw/+du84FAl/WyzUACgkQjPlrw/+d
+u87mdhAAhTZNe6N6GQrlIn+f6J6IjSoNRrEwuXbDstWIQMwU/KDUOEToZHqfWTxh
+i33Enw5soIZnAoTMaIuMJIi550+jhPPEWnLpU9PjDMJa64foGDfBSRHZsBoKyl/G
+qUauMpRNU04L1ujsCeyt7oriVEZpCBFz201YL+9Wi1JBvWUB5JkMD2sk5gcDcbCs
+3KjYK7f7RVRmRrs7ZSEqyxm0G8U0JObWK8sk+iiy+PM/AotZTiNhmDe/u+VPMJqT
+7KY1+hb/WeNSxENGTFKmNAA3HSb6epXTHi8O7/Hz1XY8OQxHHlBIQ/M3d7KTxJ+v
+Dudz317+PzdhUycd3XQxD4kCW/i1KoVJsvXTYllYdRk8n4azD0/YmHCxbFv0qPxc
+5xFoM8pR/vxg18hRoY/ve1Bea80sFmCvzvz6GEOw8hMRp9jvrzQ21eeqgE+MciBd
+kM9m0PUBbNAwurKKlb95Yvp0cWr6+Sd6Tm6AesEt54gOoKSDD6BkWEA88omdhNlI
+zLr3LI+/Y8I0ooYvaGEgGJyMcLBytHzA/RMO29lgISkwJvF0u6+gCvxwdFMmdP4K
+Rny48+h5k9FDsrnWGxKzHYQKhP2HwpKS9313fwALsq7zaMvFQvDvEPZYnp7v93mN
+DCkALXOriXnUt50a7fAk6PtP3D0JZ3SLTBKw9EqFlzOUzRAqdRA=
+=cewA
+-----END PGP SIGNATURE-----

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Torgap Onion is an experiment that combines `minisig` Ed25519 keys with Tor to e
 * **[torgap-sig](https://github.com/BlockchainCommons/torgap-sig) \(Rust library\).** A fork of `rust-minisig` with support for Tor onion v3, testbedding `did:onion`, which enables DID and VCs lookups via a Torgap.
 * **[torgap-sig-cli-rust](https://github.com/BlockchainCommons/torgap-sig-cli-rust) \(CLI tool\).** A fork of `rsign2` with support for Tor onion v3, with support for Tor onion v3, testbedding `did:onion:*`, which enables DID and VCs lookups via a Torgap.
 * **[did-method-method](https://github.com/BlockchainCommons/did-method-onion)** A very preliminary [DID](https://www.w3.org/TR/did-core/) Method `did:onion:*` for using Tor onion transport and keys for the emerging [W3C Decentralized Identifier 1.0](https://www.w3.org/TR/did-core/) and [W3C Verifiable Credentials (VC) Data Model 1.0 ](https://www.w3.org/TR/vc-data-model/) standards.
+* **[torgap-opentimestamps](https://github.com/BlockchainCommons/torgap-opentimestamps) \(Linode Stackscript\).** A [Linode](https://www.linode.com/?r=23211828bc517e2cb36e0ca81b91cc8c0e1b2d96) installer [script](https://github.com/BlockchainCommons/torgap-opentimestamps/blob/master/StackScript/torgap-opentimestamps.sh) to automate installation of OpenTimestamps (optionally with a Bitcoin full node verification) behind an onion service
+  * **Live demo** [http://3xcaaswwserqnox56z7d7wifwyxm2jsdv4fniffym5jwncqx3qr7uzid.onion/]()
 
 ## Status - Varied
 


### PR DESCRIPTION
## Abstract

Include torgap-opentimestamps repo and its stackscript

The StackScript allows you to choose to install Bitcoin Core to perform verification of timestamps. Otherwise, the verification is delegated to a public Esplora explorer. You can also choose to timestamp files with publicly available Calendar servers and upgrade the incomplete timestamps.

I did not include the support for private calendar.